### PR TITLE
README.md: code blocks fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ make connect-memory CONNECTOR=chatgpt SOURCE=/path/to/export.zip MAX_ITEMS=100
 
 # Direct CLI usage
 python memory_connect.py chatgpt /path/to/export.zip --output ./memory --max-items 100
-```
+
 #### Notion Workspace Import
 ```bash
 # Basic usage
@@ -174,6 +174,7 @@ make connect-memory CONNECTOR=notion SOURCE=/path/to/notion-export.zip
 make connect-memory CONNECTOR=notion SOURCE=/path/to/export.zip OUTPUT=./memory/custom
   
 python memory_connectors/memory_connect.py notion /path/to/export.zip --output ./memory
+```
 
 #### Getting ChatGPT Export
 1. Go to [ChatGPT Settings](https://chatgpt.com/settings/data-controls)
@@ -192,6 +193,7 @@ make connect-memory CONNECTOR=nuclino SOURCE=/path/to/export.zip OUTPUT=./memory
 
 # Direct CLI usage
 python memory_connectors/memory_connect.py nuclino /path/to/export.zip --output ./memory
+```
 
 #### Getting Notion Export
 1. Go to your Notion workspace settings
@@ -226,6 +228,7 @@ python memory_connectors/memory_connect.py github "microsoft/vscode" --max-items
 
 # Include specific content types
 python memory_connectors/memory_connect.py github "owner/repo" --include-issues --include-prs --include-wiki --token your_token
+```
 
 #### Getting GitHub Personal Access Token
 1. Go to [GitHub Settings → Tokens](https://github.com/settings/tokens)
@@ -251,6 +254,7 @@ make connect-memory CONNECTOR=google-docs SOURCE="folder_id" OUTPUT=./memory/cus
 
 # Direct CLI usage with interactive token input
 python memory_connectors/memory_connect.py google-docs "1ABC123DEF456_folder_id" --max-items 15
+```
 
 #### Getting Google Drive Access Token
 
@@ -303,6 +307,7 @@ memory/mcp-server/
         └── conversations/      # Individual conversation files
             ├── conv_0-project-discussion.md
             └── conv_1-technical-planning.md
+```
   
 ### Testing Your Memory
 


### PR DESCRIPTION
The code \`\`\` quotes were in the wrong places in README ruining the formatting.